### PR TITLE
Pass the export_manager_hash to the Exporter as we receive it

### DIFF
--- a/app/controllers/dradis/plugins/html_export/base_controller.rb
+++ b/app/controllers/dradis/plugins/html_export/base_controller.rb
@@ -8,15 +8,13 @@ module Dradis
         # It uses the template at: ./vendor/plugins/html_export/template.html.erb
         def index
           # these come from Export#create
-          export_manager = session[:export_manager].with_indifferent_access
+          export_manager_hash = session[:export_manager].with_indifferent_access
 
           exporter = Dradis::Plugins::HtmlExport::Exporter.new(
-            content_service: export_manager[:content_service].constantize.new
+            content_service: export_manager_hash[:content_service].constantize.new
           )
 
-          doc = exporter.export(
-            template: export_manager[:template]
-          )
+          doc = exporter.export(export_manager_hash)
 
           render type: 'text/html', text: doc
         end

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -11,8 +11,9 @@ module Dradis
         def export(args = {})
           template_path       = args.fetch(:template)
           template_properties = ::ReportTemplateProperties.find_by_template_file(File.basename(template_path)) rescue nil
+          project             = args.key?(:project_id) ? Project.find_by_id(args[:project_id]) : nil
 
-          # Build title
+          # Build title and project data
           title = Dradis.constants.include?(:Core) ? Dradis::Core::VERSION::STRING : Core::Pro::VERSION::string
           logger.debug{ "Report title: #{title}"}
 

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -13,7 +13,7 @@ module Dradis
           template_properties = ::ReportTemplateProperties.find_by_template_file(File.basename(template_path)) rescue nil
           project             = args.key?(:project_id) ? Project.find_by_id(args[:project_id]) : nil
 
-          # Build title and project data
+          # Build title
           title = Dradis.constants.include?(:Core) ? Dradis::Core::VERSION::STRING : Core::Pro::VERSION::string
           logger.debug{ "Report title: #{title}"}
 


### PR DESCRIPTION
We were loosing key @project information on the process of handing over to the add-on's Export class.