### PR TITLE
Fix Issue Sorting

### DIFF
--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -35,7 +35,7 @@ module Dradis
               logger.debug{ "Template properties define a sort field: #{sort_by}. Sorting..." }
 
               # FIXME: Assume the Field :type is :number, so cast .to_f and sort
-              issues.sort! do |a, b|
+              issues.to_a.sort! do |a, b|
                 b.fields.fetch(sort_by, '0').to_f <=> a.fields.fetch(sort_by, '0').to_f
               end
 

--- a/lib/dradis/plugins/html_export/gem_version.rb
+++ b/lib/dradis/plugins/html_export/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 9
-        TINY  = 0
+        TINY  = 1
         PRE   = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
Currently, if Issue Sorting is set in the Report Template Properties (only available in Dradis Pro), the HTML export will crash with the following error: 

![image](https://user-images.githubusercontent.com/11186655/41120774-2bb559e2-6a5c-11e8-8403-1f3e17d126a5.png)

This PR resolves the error so that the report template properties no longer crash HTML exports. 