### PR TITLE
upgrade RedCloth to 4.3.2

### DIFF
--- a/dradis-html_export.gemspec
+++ b/dradis-html_export.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   # Note markup
   spec.add_dependency 'rails_autolink', '~> 1.1'
-  spec.add_dependency 'RedCloth', '4.3.1'
+  spec.add_dependency 'RedCloth', '~> 4.3.2'
 
   # gem.add_development_dependency 'capybara', '~> 1.1.3'
   # gem.add_development_dependency 'database_cleaner'


### PR DESCRIPTION
RedCloth 4.3.1 has a security vulnerability, see CVE-2012-6684