### PR TITLE
Render using main app markup method (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Dradis Framework 3.12 (XXX) ##
 
-  *   Render html using ActionView with app markup method.
-  
+  *   Render html using main app `markup` method.
+
 ## Dradis Framework 3.11 (November, 2018) ##
 
 *   No changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.12 (XXX) ##
+
+  *   Render html using ActionView with app markup method.
+  
 ## Dradis Framework 3.11 (November, 2018) ##
 
 *   No changes.

--- a/app/controllers/dradis/plugins/html_export/base_controller.rb
+++ b/app/controllers/dradis/plugins/html_export/base_controller.rb
@@ -7,6 +7,7 @@ module Dradis
         #
         # It uses the template at: ./vendor/plugins/html_export/template.html.erb
         def index
+          Dradis::Plugins::HtmlExport::Exporter.send(:include, ::ApplicationHelper)
           exporter = Dradis::Plugins::HtmlExport::Exporter.new(export_options)
           html     = exporter.export
 

--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -27,7 +27,7 @@ module Dradis
         end
 
         initializer 'dradis-html_export.include_helper' do
-          ActiveSupport.on_load :action_controller do
+          ActiveSupport.on_load :action_controller_base do
             Dradis::Plugins::HtmlExport::Exporter.send(:include, ::ApplicationHelper)
           end
         end

--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -25,12 +25,6 @@ module Dradis
             mount Dradis::Plugins::HtmlExport::Engine => '/export/html'
           end
         end
-
-        initializer 'dradis-html_export.include_helper' do
-          ActiveSupport.on_load :action_controller_base do
-            Dradis::Plugins::HtmlExport::Exporter.send(:include, ::ApplicationHelper)
-          end
-        end
       end
     end
   end

--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -25,6 +25,12 @@ module Dradis
             mount Dradis::Plugins::HtmlExport::Engine => '/export/html'
           end
         end
+
+        initializer 'dradis-html_export.include_helper' do
+          ActiveSupport.on_load :action_controller do
+            Dradis::Plugins::HtmlExport::Exporter.send(:include, ::ApplicationHelper)
+          end
+        end
       end
     end
   end

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -55,24 +55,6 @@ module Dradis
           erb = ERB.new( File.read(template_path) )
           erb.result( binding )
         end
-
-        private
-
-        # FIXME This method is a behavioural duplicate of ApplicationHelper#markup
-        # from the main app, it would be better to re-use that code.
-        def markup(text)
-          return unless text.present?
-
-          # escape HTML 'manually' instead of using RedCloth's "filter_html"
-          # for security reasons
-          output = ERB::Util.html_escape(text.dup)
-
-          Hash[ *text.scan(/#\[(.+?)\]#[\r|\n](.*?)(?=#\[|\z)/m).flatten.collect{ |str| str.strip } ].keys.each do |field|
-            output.gsub!(/#\[#{Regexp.escape(field)}\]#[\r|\n]/, "h4. #{field}\n\n")
-          end
-
-          auto_link(RedCloth.new(output, [:no_span_caps]).to_html).html_safe
-        end
       end
     end
   end


### PR DESCRIPTION
### Spec
In this html export add-on we had this method:
https://github.com/dradis/dradis-html_export/blob/master/lib/dradis/plugins/html_export/exporter.rb#L63 (note the `FIXME` comment)

and in Dradis app we have the same method:
https://github.com/dradis/dradis-ce/blob/master/app/helpers/application_helper.rb#L26

The method in Dradis has evolved, and does more stuff.

With this PR I am trying to use that method from the add-on too, fixing the `FIXME` comment.

[dradis/dradis-ce#413](https://github.com/dradis/dradis-ce/issues/413)

### How to test
Html exporting should keep working both from the app and the Thor task.