### PR TITLE
Render using main app markup method (v3)

### DIFF
--- a/lib/dradis/plugins/html_export.rb
+++ b/lib/dradis/plugins/html_export.rb
@@ -1,5 +1,4 @@
 require 'dradis/plugins/html_export/engine'
-require 'dradis/plugins/html_export/exporter'
 require 'dradis/plugins/html_export/version'
 
 module Dradis

--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -25,6 +25,14 @@ module Dradis
             mount Dradis::Plugins::HtmlExport::Engine => '/export/html'
           end
         end
+
+        config.after_initialize do
+          # Dradis::Plugins::HtmlExport::Exporter needs ::ApplicationHelper
+          # module from the main app. Here we are forcing that class to be
+          # loaded once the main app is loaded, so it can use
+          # 'include ;;ApplicationHelper' without surprises
+          require 'dradis/plugins/html_export/exporter'
+        end
       end
     end
   end

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -7,6 +7,8 @@ module Dradis
         include ::ActionView::Helpers::TextHelper
         # For auto_link feature (requires #mail_to)
         include ::ActionView::Helpers::UrlHelper
+        # For 'markup' method
+        include ::ApplicationHelper
 
         def export(args = {})
           template_path       = options.fetch(:template)
@@ -54,24 +56,6 @@ module Dradis
           # Render template
           erb = ERB.new( File.read(template_path) )
           erb.result( binding )
-        end
-
-        private
-
-        # FIXME This method is a behavioural duplicate of ApplicationHelper#markup
-        # from the main app, it would be better to re-use that code.
-        def markup(text)
-          return unless text.present?
-
-          # escape HTML 'manually' instead of using RedCloth's "filter_html"
-          # for security reasons
-          output = ERB::Util.html_escape(text.dup)
-
-          Hash[ *text.scan(/#\[(.+?)\]#[\r|\n](.*?)(?=#\[|\z)/m).flatten.collect{ |str| str.strip } ].keys.each do |field|
-            output.gsub!(/#\[#{Regexp.escape(field)}\]#[\r|\n]/, "h4. #{field}\n\n")
-          end
-
-          auto_link(RedCloth.new(output, [:no_span_caps]).to_html).html_safe
         end
       end
     end


### PR DESCRIPTION
### Spec
In this html export add-on we had this method:
https://github.com/dradis/dradis-html_export/blob/master/lib/dradis/plugins/html_export/exporter.rb#L63 (note the `FIXME` comment)

and in Dradis app we have the same method:
https://github.com/dradis/dradis-ce/blob/master/app/helpers/application_helper.rb#L26

The method in Dradis has evolved, and does more stuff.

With this PR we are trying to call that method from the add-on too, fixing the `FIXME` comment.

[dradis/dradis-ce#413](https://github.com/dradis/dradis-ce/issues/413)

### How to test
Html exporting should keep working both from the app and the Thor task.