### PR TITLE
Use NamingService to rename html export filenames

### DIFF
--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -15,9 +15,15 @@ class HtmlExportTasks < Thor
 
     report_path = options.output || Rails.root
     unless report_path.to_s =~ /\.html\z/
-      date      = DateTime.now.strftime("%Y-%m-%d")
-      sequence  = Dir.glob(File.join(report_path, "dradis-report_#{date}_*.html")).collect { |a| a.match(/_([0-9]+)\.html\z/)[1].to_i }.max || 0
-      report_path = File.join(report_path, "dradis-report_#{date}_#{sequence + 1}.html")
+      date = DateTime.now.strftime("%Y-%m-%d")
+      base_filename = "dradis-report_#{date}.html"
+
+      report_filename = NamingService.name_file(
+        original_filename: base_filename,
+        pathname: Pathname.new(report_path)
+      )
+
+      report_path = File.join(report_path, report_filename)
     end
 
     if template = options.template


### PR DESCRIPTION
### Summary
This PR uses `NamingService` in dradis main app to find suitable filenames for html exports.

### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
