### PR TITLE
Add a fix for Rails 6 HTML rendering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.21 (MMM, 2021) ##
+
+*   Add a fix for Rails 6 not allowing HTML rendering outside the view directory.
+
 ## Dradis Framework 3.20 (December, 2020) ##
 
 *   Add an option in the exporter to pass a controller for rendering.

--- a/app/controllers/dradis/plugins/html_export/base_controller.rb
+++ b/app/controllers/dradis/plugins/html_export/base_controller.rb
@@ -8,11 +8,7 @@ module Dradis
         # It uses the template at: ./vendor/plugins/html_export/template.html.erb
         def index
           exporter = Dradis::Plugins::HtmlExport::Exporter.new(export_options)
-          html     = exporter.export do |filename, template|
-            destination_path = Rails.root.join("app/views/tmp/#{filename}")
-            FileUtils.mkdir_p(File.dirname(destination_path))
-            FileUtils.cp(template, destination_path)
-          end
+          html     = exporter.export
 
           render html: html.html_safe
         end

--- a/app/controllers/dradis/plugins/html_export/base_controller.rb
+++ b/app/controllers/dradis/plugins/html_export/base_controller.rb
@@ -9,6 +9,7 @@ module Dradis
         def index
           exporter = Dradis::Plugins::HtmlExport::Exporter.new(export_options)
           html     = exporter.export
+          exporter.remove_tmp_folder
 
           render html: html.html_safe
         end

--- a/app/controllers/dradis/plugins/html_export/base_controller.rb
+++ b/app/controllers/dradis/plugins/html_export/base_controller.rb
@@ -8,7 +8,11 @@ module Dradis
         # It uses the template at: ./vendor/plugins/html_export/template.html.erb
         def index
           exporter = Dradis::Plugins::HtmlExport::Exporter.new(export_options)
-          html     = exporter.export
+          html     = exporter.export do |filename, template|
+            destination_path = Rails.root.join("app/views/tmp/#{filename}")
+            FileUtils.mkdir_p(File.dirname(destination_path))
+            FileUtils.cp(template, destination_path)
+          end
 
           render html: html.html_safe
         end

--- a/app/controllers/dradis/plugins/html_export/base_controller.rb
+++ b/app/controllers/dradis/plugins/html_export/base_controller.rb
@@ -9,7 +9,6 @@ module Dradis
         def index
           exporter = Dradis::Plugins::HtmlExport::Exporter.new(export_options)
           html     = exporter.export
-          exporter.remove_tmp_folder
 
           render html: html.html_safe
         end

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -95,19 +95,19 @@ module Dradis
                        "Dradis Community Edition v#{Dradis::CE.version}"
                      end
         end
-      end
 
-      def with_temporary_template(original, &block)
-        filename = File.basename(Dir::Tmpname.create(['', '.html.erb']) {})
-        destination_path = Rails.root.join('app', 'views', 'tmp', filename)
+        def with_temporary_template(original, &block)
+          filename = File.basename(Dir::Tmpname.create(['', '.html.erb']) {})
+          destination_path = Rails.root.join('app', 'views', 'tmp', filename)
 
-        FileUtils.mkdir_p(File.dirname(destination_path))
-        FileUtils.cp(original, destination_path)
+          FileUtils.mkdir_p(File.dirname(destination_path))
+          FileUtils.cp(original, destination_path)
 
-        yield(template_name)
-      ensure
-        file_path = Rails.root.join("app/views/tmp/#{filename}")
-        File.delete(file_path) if File.exists?(file_path)
+          yield("tmp/#{filename}")
+        ensure
+          file_path = Rails.root.join("app/views/tmp/#{filename}")
+          File.delete(file_path) if File.exists?(file_path)
+        end
       end
     end
   end

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -11,8 +11,8 @@ module Dradis
           filename = tmp_filename
 
           copy_template_to_view_folder(
-            original_template_path: options[:template],
-            destination_filename: filename
+            destination_filename: filename,
+            original_template_path: options[:template]
           )
 
           # Render template
@@ -109,7 +109,7 @@ module Dradis
           "#{SecureRandom.hex}.html.erb"
         end
 
-        def copy_template_to_view_folder(original_template_path:, destination_filename:)
+        def copy_template_to_view_folder(destination_filename:, original_template_path:)
           destination_path = Rails.root.join("app/views/tmp/#{destination_filename}")
           FileUtils.mkdir_p(File.dirname(destination_path))
           FileUtils.cp(original_template_path, destination_path)

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -11,7 +11,7 @@ module Dradis
 
           # Render template
           controller.render(
-            file: options.fetch(:template),
+            template: tmp_template(original_template_path: options.fetch(:template)),
             layout: false,
             locals: {
               categorized_issues: categorized_issues,
@@ -26,6 +26,10 @@ module Dradis
               user: options[:user]
             }
           )
+        end
+
+        def remove_tmp_folder
+          FileUtils.remove_dir(Rails.root.join('app/views/tmp'))
         end
 
         private
@@ -93,6 +97,16 @@ module Dradis
                      else
                        "Dradis Community Edition v#{Dradis::CE.version}"
                      end
+        end
+
+        def tmp_template(original_template_path:)
+          filename = File.basename(original_template_path)
+          destination_path = Rails.root.join("app/views/tmp/templates/html_export/#{filename}")
+
+          FileUtils.mkdir_p(File.dirname(destination_path))
+          FileUtils.cp(original_template_path, destination_path)
+
+          "tmp/templates/html_export/#{filename}"
         end
       end
     end

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -106,7 +106,7 @@ module Dradis
         end
 
         def tmp_filename
-          "#{SecureRandom.hex}.html.erb"
+          File.basename(Dir::Tmpname.create(['', '.html.erb']) {})
         end
 
         def copy_template_to_view_folder(destination_filename:, original_template_path:)

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -10,7 +10,7 @@ module Dradis
           controller = args[:controller] || ApplicationController
 
           # Render template
-          controller.render(
+          html = controller.render(
             template: tmp_template(original_template_path: options.fetch(:template)),
             layout: false,
             locals: {
@@ -26,6 +26,10 @@ module Dradis
               user: options[:user]
             }
           )
+
+          remove_tmp_folder
+
+          html
         end
 
         def remove_tmp_folder

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -38,10 +38,6 @@ module Dradis
           html
         end
 
-        def remove_tmp_folder
-          FileUtils.remove_dir(Rails.root.join('app/views/tmp'))
-        end
-
         private
         def log_report
           logger.debug { "Report title: #{title}" }

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -8,9 +8,12 @@ module Dradis
           log_report
 
           controller = args[:controller] || ApplicationController
-
           filename = File.basename(Dir::Tmpname.create(['', '.html.erb']) {})
-          yield(filename, options[:template])
+
+          copy_template(
+            filename: filename,
+            template: options[:template]
+          )
 
           # Render template
           controller.render(
@@ -99,6 +102,12 @@ module Dradis
                      else
                        "Dradis Community Edition v#{Dradis::CE.version}"
                      end
+        end
+
+        def copy_template(filename:, template:)
+          destination_path = Rails.root.join("app/views/tmp/#{filename}")
+          FileUtils.mkdir_p(File.dirname(destination_path))
+          FileUtils.cp(template, destination_path)
         end
       end
     end

--- a/lib/dradis/plugins/html_export/gem_version.rb
+++ b/lib/dradis/plugins/html_export/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 20
+        MINOR = 21
         TINY  = 0
         PRE   = nil
 

--- a/spec/fixtures/files/template.html.erb
+++ b/spec/fixtures/files/template.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>My Title</title>
+  </head>
+  <body>
+    <h2>Issues</h2>
+    <% issues.each do |issue| %>
+      <p><%= markup(issue.text) %></p>
+    <% end %>
+  </body>
+</html>

--- a/spec/lib/dradis/plugins/html_export/exporter_spec.rb
+++ b/spec/lib/dradis/plugins/html_export/exporter_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe Dradis::Plugins::HtmlExport::Exporter do
+  let!(:project) { create(:project) }
+  let!(:issues) { create_list(:issue, 3, node: project.issue_library) }
+
+  let(:export_options) do
+    {
+      project_id: project.id,
+      template: File.join(
+        File.dirname(__FILE__),
+        '../../../../',
+        'fixtures',
+        'files',
+        'template.html.erb'
+      )
+    }
+  end
+
+  after do
+    exporter.remove_tmp_folder
+  end
+
+  let(:exporter) { described_class.new(export_options) }
+
+  it 'exports html' do
+    html = exporter.export
+
+    issues.each do |issue|
+      expect(html.include?(issue.title))
+    end
+  end
+end

--- a/spec/lib/dradis/plugins/html_export/exporter_spec.rb
+++ b/spec/lib/dradis/plugins/html_export/exporter_spec.rb
@@ -7,18 +7,10 @@ describe Dradis::Plugins::HtmlExport::Exporter do
   let(:export_options) do
     {
       project_id: project.id,
-      template: File.join(
-        File.dirname(__FILE__),
-        '../../../../',
-        'fixtures',
-        'files',
-        'template.html.erb'
+      template: Dradis::Plugins::HtmlExport::Engine.root.join(
+        'spec/fixtures/files/template.html.erb'
       )
     }
-  end
-
-  after do
-    exporter.remove_tmp_folder
   end
 
   let(:exporter) { described_class.new(export_options) }


### PR DESCRIPTION
### Summary

This PR adds a fix for Rails 6 not rendering html erb files outside the `app/views` directory.
Fix by copying the template from the shared folder to the view directory. Then remove the copy from the tmp folder after processing.

### Copyright assignment
Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
