### PR TITLE
show html tab if no other tabs are active

### DIFF
--- a/app/assets/javascripts/dradis/plugins/html_export/export.js
+++ b/app/assets/javascripts/dradis/plugins/html_export/export.js
@@ -1,0 +1,14 @@
+document.addEventListener('turbolinks:load', function () {
+  // Show the HTML tab on page load if no tabs are active. We can't hardcode
+  // an active tab in CE as it will break the active tab in Pro set by Word.
+  if (
+    document.querySelector('body.export.index') &&
+    !document.querySelectorAll('[data-bs-toggle~=tab].active').length
+  ) {
+    const htmlTab = document.querySelector(
+      '[data-bs-toggle~=tab][href="#plugin-html_export"]'
+    );
+    new bootstrap.Tab(htmlTab);
+    bootstrap.Tab.getInstance(htmlTab).show();
+  }
+});

--- a/app/assets/javascripts/dradis/plugins/html_export/manifests/tylium.js
+++ b/app/assets/javascripts/dradis/plugins/html_export/manifests/tylium.js
@@ -1,0 +1,1 @@
+//= require dradis/plugins/html_export/export

--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -15,7 +15,7 @@ module Dradis
         include Dradis::Plugins::Base
 
         # plugin_name 'HTML export'
-        provides :export, :rtp
+        provides :addon, :export, :rtp
         description 'Generate advanced HTML reports'
 
         initializer 'dradis-html_export.mount_engine' do


### PR DESCRIPTION
### Summary

The PR fixes a bug in CE where no tabs are active in the Export Manager on page load.