### PR TITLE
show the html tab by default in CE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.9.1 (June 2023)
+  - Show HTML export tab by default in CE's export view
+
 v4.9.0 (June 2023)
   - Update views for compatibility with Bootstrap 5
 

--- a/app/views/dradis/plugins/html_export/export/_index-content.html.erb
+++ b/app/views/dradis/plugins/html_export/export/_index-content.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :div, id: 'plugin-html_export', class: 'tab-pane fade' do %>
+<%= content_tag :div, id: 'plugin-html_export', class: class_names('tab-pane', 'fade', 'active show': !defined?(Dradis::Pro)) do %>
   <%= form_tag project_export_manager_path(current_project), target: '_blank' do %>
     <%= hidden_field_tag :plugin, :html_export %>
     <%= hidden_field_tag :route, :root %>

--- a/app/views/dradis/plugins/html_export/export/_index-tabs.html.erb
+++ b/app/views/dradis/plugins/html_export/export/_index-tabs.html.erb
@@ -1,3 +1,3 @@
 <li class='nav-item'>
-  <a href='#plugin-html_export' class='nav-link' data-bs-toggle='tab'>HTML</a>
+  <a href='#plugin-html_export' class="<%= class_names('nav-link', active: !defined?(Dradis::Pro)) %>" data-bs-toggle='tab'>HTML</a>
 </li>

--- a/lib/dradis/plugins/html_export/gem_version.rb
+++ b/lib/dradis/plugins/html_export/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 9
-        TINY  = 0
+        TINY  = 1
         PRE   = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
### Summary

This PR fixes a bug where CE users didn't have any tabs shown by default in CE after the BS5 update