### PR TITLE
Fix basic template and include rails text helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v4.9.1 (June 2023)
+v4.9.2 (June 2023)
   - Fix the default templates
 
 v4.9.0 (June 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.9.1 (June 2023)
+  - Fix the default templates
+
 v4.9.0 (June 2023)
   - Update views for compatibility with Bootstrap 5
 

--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -2,6 +2,8 @@ module Dradis
   module Plugins
     module HtmlExport
       class Exporter < Dradis::Plugins::Export::Base
+        include ActionView::Helpers::TextHelper
+
         def export(args = {})
           log_report
 

--- a/lib/dradis/plugins/html_export/gem_version.rb
+++ b/lib/dradis/plugins/html_export/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 9
-        TINY  = 1
+        TINY  = 2
         PRE   = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/lib/dradis/plugins/html_export/gem_version.rb
+++ b/lib/dradis/plugins/html_export/gem_version.rb
@@ -9,10 +9,10 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 9
-        TINY  = 0
+        TINY  = 1
         PRE   = nil
 
-        STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+        STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
       end
     end
   end

--- a/spec/lib/dradis/plugins/html_export/exporter_spec.rb
+++ b/spec/lib/dradis/plugins/html_export/exporter_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Dradis::Plugins::HtmlExport::Exporter do
+  before { Dradis::Plugins::HtmlExport::Exporter.include(ApplicationHelper) }
+
   let!(:project) { create(:project, :with_team) }
 
   let!(:content_blocks) { create_list(:content_block, 5, project: project) }
@@ -27,6 +29,46 @@ describe Dradis::Plugins::HtmlExport::Exporter do
 
       issues.each do |issue|
         expect(html.include?(issue.title))
+      end
+    end
+  end
+
+  context 'templates' do
+    describe 'basic template' do
+      let(:export_options) do
+        {
+          project_id: project.id,
+          template: Dradis::Plugins::HtmlExport::Engine.root.join(
+            'templates/basic.html.erb'
+          )
+        }
+      end
+
+      it 'exports html' do
+        html = exporter.export
+
+        issues.each do |issue|
+          expect(html.include?(issue.title))
+        end
+      end
+    end
+
+    describe 'default template' do
+      let(:export_options) do
+        {
+          project_id: project.id,
+          template: Dradis::Plugins::HtmlExport::Engine.root.join(
+            'templates/default_dradis_template_v3.0.html.erb'
+          )
+        }
+      end
+
+      it 'exports html' do
+        html = exporter.export
+
+        issues.each do |issue|
+          expect(html.include?(issue.title))
+        end
       end
     end
   end

--- a/templates/basic.html.erb
+++ b/templates/basic.html.erb
@@ -26,14 +26,14 @@
     <section>
       <h2>Issues</h2>
       <% issues.each do |issue| %>
-      <div class="note"><%= markup(issue.text) %></div>
+      <div class="note"><%= markup(issue.text, liquid: true) %></div>
       <% end %>
     </section>
 
     <section>
       <h2>Notes</h2>
       <% notes.each do |note| %>
-      <div class="note"><%= markup(note.text) %></div>
+      <div class="note"><%= markup(note.text, liquid: true) %></div>
       <% end %>
     </section>
 

--- a/templates/basic.html.erb
+++ b/templates/basic.html.erb
@@ -31,7 +31,7 @@
     </section>
 
     <section>
-      <h2>Notes assigned to the <%= reporting_cat.name %> category</h2>
+      <h2>Notes</h2>
       <% notes.each do |note| %>
       <div class="note"><%= markup(note.text) %></div>
       <% end %>

--- a/templates/default_dradis_template_v3.0.html.erb
+++ b/templates/default_dradis_template_v3.0.html.erb
@@ -70,7 +70,7 @@
       <% notes.each do |note| %>
       <div class="panel panel-default">
         <div class="panel-body">
-          <%= markup(note.text) %>
+          <%= markup(note.text, liquid: true) %>
         </div>
       </div>
       <% end %>
@@ -81,7 +81,7 @@
       <% issues.each do |issue| %>
       <div class="panel panel-default">
         <div class="panel-body">
-          <%= markup(issue.text) %>
+          <%= markup(issue.text, liquid: true) %>
 
           <h3>Assets affected by this issue</h3>
           <% if issue.affected.empty? %>
@@ -101,7 +101,7 @@
                   <section id="evidence_for_#{node.id}">
                     <% if instances.count == 1 %>
                       <div class="content-textile" id="node_<%= node.id %>_instance_0">
-                        <%= markup(instances.first.content) %>
+                        <%= markup(instances.first.content, liquid: true) %>
                       </div>
                     <% else %>
                       <ul class="nav nav-tabs">
@@ -113,7 +113,7 @@
                       <div class="tab-content">
                         <% instances.each_with_index do |evidence, i| %>
                         <div class="content-textile tab-pane<%= ' active' if i==0 %>" id="node_<%= node.id %>_instance_<%= i %>">
-                          <%= markup(evidence.content) %>
+                          <%= markup(evidence.content, liquid: true) %>
                         </div>
                         <% end %>
                       </div>


### PR DESCRIPTION
### Summary

As part of the recent implementation of liquid assigns for HTML, the rendering mechanism used in HTML Export was changed from Controller#render to plain ERB parsing. This meant that support for convenience methods such as `pluralize` was removed.

Also as part of the change, the `reporting_cat` was removed but the basic template was not updated.

**Proposed solution**
- Include Rails' TextHelper to the exporter
- Update the basic.html.erb template


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
