### PR TITLE
Fix typo in engine.rb initializer block

### DIFF
--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -24,7 +24,7 @@ module Dradis
           end
         end
 
-        initializer 'draids-html_export.include_helper' do
+        initializer 'dradis-html_export.include_helper' do
           ActiveSupport.on_load(:action_view) do
             Dradis::Plugins::HtmlExport::Exporter.include(ApplicationHelper)
           end


### PR DESCRIPTION
### Summary
Initializer to include Application Helper has a typo, meaning that application helper is not being included