### PR TITLE
Include HTML Export in the tools manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-[v#.#.#] ([month] 2023)
+v4.10.0 ([month] 2023)
   - Add support for enabling/disabling
   - Prevent exporting reports without any HTML templates
+  - Fix the default templates
+  - Implement handling of HTML exports directly from Tylium
+  - Update views for compatibility with Font Awesome 6
   - Upgraded gems:
     - [gem]
   - Bugs fixes:
@@ -11,11 +14,6 @@
     - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
-
-v4.10.0 (Month 2023)
-  - Fix the default templates
-  - Implement handling of HTML exports directly from Tylium
-  - Update views for compatibility with Font Awesome 6
 
 v4.9.1 (June 2023)
   - Show HTML export tab by default in CE's export view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 [v#.#.#] ([month] 2023)
+  - Add support for enabling/disabling
   - Prevent exporting reports without any HTML templates
   - Upgraded gems:
     - [gem]

--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -28,8 +28,8 @@ module Dradis
           Rails.application.routes.append do
             # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
             # check inside the block to ensure the routes can be re-enabled without a server restart
-            if Dradis::Plugins::HtmlExport::Engine.enabled?
-              mount Dradis::Plugins::HtmlExport::Engine => '/', as: :html_export
+            if Engine.enabled?
+              mount Engine => '/', as: :html_export
             end
           end
         end

--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -18,11 +18,9 @@ module Dradis
         provides :export, :rtp
         description 'Generate advanced HTML reports'
 
-        initializer 'dradis-html_export.disable_by_default' do
-          ActiveSupport.on_load(:configuration) do
-            unless ::Configuration.find_by_name('html_export:enabled')
-              Dradis::Plugins::HtmlExport::Engine.disable!
-            end
+        if defined?(Dradis::Pro)
+          addon_settings :html_export do
+            settings.default_enabled = false
           end
         end
 

--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -18,11 +18,9 @@ module Dradis
         provides :export, :rtp
         description 'Generate advanced HTML reports'
 
-        if defined?(Dradis::Pro)
-          addon_settings :html_export do
-            settings.default_enabled = false
-          end
-        end
+        addon_settings :html_export do
+          settings.default_enabled = false
+        end if defined?(Dradis::Pro)
 
         initializer 'dradis-html_export.mount_engine' do
           Rails.application.routes.append do

--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -18,9 +18,21 @@ module Dradis
         provides :export, :rtp
         description 'Generate advanced HTML reports'
 
+        initializer 'dradis-html_export.disable_by_default' do
+          ActiveSupport.on_load(:configuration) do
+            unless ::Configuration.find_by_name('html_export:enabled')
+              Dradis::Plugins::HtmlExport::Engine.disable!
+            end
+          end
+        end
+
         initializer 'dradis-html_export.mount_engine' do
           Rails.application.routes.append do
-            mount Dradis::Plugins::HtmlExport::Engine => '/', as: :html_export
+            # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
+            # check inside the block to ensure the routes can be re-enabled without a server restart
+            if Dradis::Plugins::HtmlExport::Engine.enabled?
+              mount Dradis::Plugins::HtmlExport::Engine => '/', as: :html_export
+            end
           end
         end
 


### PR DESCRIPTION
### Summary

**Proposed solution**

- Disable HTML Exporter by default
  - HTML Exporter needs to be enabled in the Tools Manager
  - When the HTML Exporter is enabled and the configuration is set, don't disable on load anymore.
- Add HTML Exporter to the integrations manager


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
