### PR TITLE
Rails 7 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+[v#.#.#] ([month] [YYYY])
+  - Update initializer to work with Rails 7
+  - Upgraded gems:
+    - [gem]
+  - Bugs fixes:
+    - [future tense verb] [bug fix]
+    - Bug tracker items:
+      - [item]
+  - Security Fixes:
+    - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+    - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+    - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+
 v4.10.1 (September 2023)
   - Fix mounting for routes when building the appliance from scratch
 

--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -23,12 +23,14 @@ module Dradis
         end if defined?(Dradis::Pro)
 
         initializer 'dradis-html_export.mount_engine' do
-          if (ActiveRecord::Base.connection rescue false) && ::Configuration.table_exists?
-            Rails.application.routes.append do
-              # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
-              # check inside the block to ensure the routes can be re-enabled without a server restart
-              if Engine.enabled?
-                mount Engine => '/', as: :html_export
+          Rails.application.reloader.to_prepare do
+            if (ActiveRecord::Base.connection rescue false) && ::Configuration.table_exists?
+              Rails.application.routes.append do
+                # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
+                # check inside the block to ensure the routes can be re-enabled without a server restart
+                if Engine.enabled?
+                  mount Engine => '/', as: :html_export
+                end
               end
             end
           end


### PR DESCRIPTION
### Summary

After the Rails 7 upgrade, there's an expected autoload error in the initializer, so we need to wrap the ::Configuration.table_exists? check in a to_prepare block



> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
