### PR TITLE
Remove configuration table check as it is now done in dradis-plugins

### DIFF
--- a/lib/dradis/plugins/html_export/engine.rb
+++ b/lib/dradis/plugins/html_export/engine.rb
@@ -24,16 +24,11 @@ module Dradis
 
         initializer 'dradis-html_export.mount_engine' do
           Rails.application.reloader.to_prepare do
-            # By default, this engine is loaded into the main app. So, upon app
-            # initialization, we first check if the DB is loaded and the Configuration
-            # table has been created, before checking if the engine is enabled
-            if (ActiveRecord::Base.connection rescue false) && ::Configuration.table_exists?
-              Rails.application.routes.append do
-                # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
-                # check inside the block to ensure the routes can be re-enabled without a server restart
-                if Engine.enabled?
-                  mount Engine => '/', as: :html_export
-                end
+            Rails.application.routes.append do
+              # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
+              # check inside the block to ensure the routes can be re-enabled without a server restart
+              if Engine.enabled?
+                mount Engine => '/', as: :html_export
               end
             end
           end


### PR DESCRIPTION
### Summary

Previously, we needed to check `if (ActiveRecord::Base.connection rescue false) && ::Configuration.table_exists?` before checking `engine.enabled?`. We are now doing this check in [dradis-plugins](https://github.com/dradis/dradis-plugins/pull/101) so we can remove it here

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~
~- [ ] Added specs~
