### PR TITLE
Update `File.exists?` to `File.exist?` for Ruby 3.4 compatibility

### DIFF
--- a/lib/dradis/plugins/html_export/exporter.rb
+++ b/lib/dradis/plugins/html_export/exporter.rb
@@ -109,7 +109,7 @@ module Dradis
           yield(destination_path)
         ensure
           file_path = Rails.root.join("app/views/tmp/#{filename}")
-          File.delete(file_path) if File.exists?(file_path)
+          File.delete(file_path) if File.exist?(file_path)
         end
       end
     end

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -27,7 +27,7 @@ class HtmlExportTasks < Thor
     end
 
     if template = options.template
-      shell.error("Template file doesn't exist") && exit(1) unless File.exists?(template)
+      shell.error("Template file doesn't exist") && exit(1) unless File.exist?(template)
       task_options[:template] = template
     end
 


### PR DESCRIPTION
### Summary

Ruby 3.2 deprecated `File.exists?` in favour of `File.exist?`. This PR updates those usages


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~
~- [ ] Added specs~
